### PR TITLE
Explicitly specifying markdown style

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,7 @@ twitter_username: nlpofftherecord
 theme: minima
 plugins:
   - jekyll-feed
+markdown: kramdown
 
 disqus:
   shortname: nlpofftherecord


### PR DESCRIPTION
This is actually the default style for Jekyll, but it's useful to have it noted here.